### PR TITLE
Layer in DataDog integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go: 1.6
+go: "1.10"
 
 install: go get -t -v ./...
 script: go test -v ./...

--- a/core/core.go
+++ b/core/core.go
@@ -110,8 +110,8 @@ func (l *Logvac) addDrain(tag string, drain DrainFunc) {
 			case <-channels.done:
 				return
 			case msg := <-channels.send:
-				// todo: ensure mist plays nice with goroutine
-				go drain(msg)
+				// don't goroutine to preserve log order
+				drain(msg)
 			}
 		}
 	}()

--- a/core/core.go
+++ b/core/core.go
@@ -45,6 +45,7 @@ type (
 		Priority int       `json:"priority"`
 		Content  string    `json:"message"`
 		Raw      []byte    `json:"raw,omitempty"`
+		PubTries int       // number of publish attempts
 	}
 
 	// Logvac defines the structure for the default logvac object

--- a/drain/datadog.go
+++ b/drain/datadog.go
@@ -89,7 +89,7 @@ func (p *Datadog) Close() error {
 	return p.connManager.conn.Close()
 }
 
-// Adapted from datadog-log-agent
+// Adapted from datadog-log-agent (github.com/DataDog/datadog-agent/pkg/logs)
 const (
 	backoffSleepTimeUnit = 2  // in seconds
 	maxBackoffSleepTime  = 30 // in seconds
@@ -128,7 +128,7 @@ func (cm *ConnectionManager) NewConnection() net.Conn {
 			return cm.conn
 		}
 		fmt.Println("Connecting to the backend:", cm.connectionString)
-		cm.retries += 1
+		cm.retries++
 		outConn, err := net.DialTimeout("tcp", cm.connectionString, timeout)
 		if err != nil {
 			fmt.Println(err)
@@ -144,6 +144,7 @@ func (cm *ConnectionManager) NewConnection() net.Conn {
 
 // CloseConnection closes a connection on the client side
 func (cm *ConnectionManager) CloseConnection(conn io.Closer) {
+	cm.conn.Close()
 	conn.Close()
 }
 

--- a/drain/datadog.go
+++ b/drain/datadog.go
@@ -1,0 +1,102 @@
+package drain
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"time"
+
+	"github.com/nanopack/logvac/core"
+)
+
+// Datadog drain implements the publisher interface for publishing logs to datadog.
+type Datadog struct {
+	Conn io.WriteCloser // connection to forward logs through
+	Key  string         // api key
+}
+
+// NewDatadogClient creates a new mist publisher
+func NewDatadogClient(key string) (*Datadog, error) {
+	_, err := net.ResolveTCPAddr("tcp", "intake.logs.datadoghq.com:10514")
+	if err != nil {
+		return nil, fmt.Errorf("Failed to resolve datadog address - %s", err.Error())
+	}
+
+	conn, err := net.DialTimeout("tcp", "intake.logs.datadoghq.com:10514", 20*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to dial datadog - %s", err.Error())
+	}
+
+	go handleServerClose(conn)
+	return &Datadog{Conn: conn, Key: key}, nil
+}
+
+// Init initializes a connection to mist
+func (p Datadog) Init() error {
+
+	// add drain
+	logvac.AddDrain("datadog", p.Publish)
+
+	return nil
+}
+
+// handleServerClose detects when the server closes a connection then closes it for the client.
+func handleServerClose(conn net.Conn) {
+	for {
+		buff := make([]byte, 1)
+		_, err := conn.Read(buff)
+		if err == io.EOF {
+			conn.Close()
+			return
+		} else if err != nil {
+			return
+		}
+	}
+}
+
+// Publish utilizes mist's Publish to "drain" a log message
+func (p Datadog) Publish(msg logvac.Message) {
+	msg.PubTries++
+	if p.Conn == nil {
+		fmt.Println("Redialing datadog")
+		conn, err := net.DialTimeout("tcp", "intake.logs.datadoghq.com:10514", 20*time.Second)
+		if err != nil {
+			if msg.PubTries <= 3 {
+				time.Sleep(2 * time.Second)
+				p.Publish(msg)
+			}
+			// return nil, fmt.Errorf("Failed to dial datadog - %s", err.Error())
+		}
+		p.Conn = conn
+		go handleServerClose(conn)
+	}
+
+	// ms := append(append([]byte(p.Key+" "), append(addExtra(), msg.Raw[4:]...)...), []byte("\n")...)
+	var ms []byte
+	if len(msg.Raw) > 4 {
+		ms = append(append([]byte(p.Key+" "), msg.Raw[4:]...), []byte("\n")...)
+	} else {
+		ms = append(append([]byte(p.Key+" "), msg.Raw...), []byte("\n")...)
+	}
+
+	fmt.Printf("Sending %s", ms)
+	// _, err := p.Conn.Write(append(append([]byte(p.Key+" "), append(addExtra(), msg.Raw[4:]...)...), []byte("\n")...))
+	_, err := p.Conn.Write(ms)
+	if err != nil {
+		fmt.Printf("Failed writing log - %s %d\n", err.Error(), msg.PubTries)
+		p.Conn.Close()
+		p.Conn = nil
+		if msg.PubTries <= 3 {
+			time.Sleep(2 * time.Second)
+			p.Publish(msg)
+		}
+	}
+}
+
+// Close closes the connection to datadog.
+func (p *Datadog) Close() error {
+	if p.Conn == nil {
+		return nil
+	}
+	return p.Conn.Close()
+}

--- a/drain/datadog.go
+++ b/drain/datadog.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/nanopack/logvac/core"
@@ -11,8 +12,9 @@ import (
 
 // Datadog drain implements the publisher interface for publishing logs to datadog.
 type Datadog struct {
-	Conn io.WriteCloser // connection to forward logs through
-	Key  string         // api key
+	connManager *ConnectionManager
+	Conn        io.WriteCloser // connection to forward logs through
+	Key         string         // api key
 }
 
 // NewDatadogClient creates a new mist publisher
@@ -22,13 +24,18 @@ func NewDatadogClient(key string) (*Datadog, error) {
 		return nil, fmt.Errorf("Failed to resolve datadog address - %s", err.Error())
 	}
 
-	conn, err := net.DialTimeout("tcp", "intake.logs.datadoghq.com:10514", 20*time.Second)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to dial datadog - %s", err.Error())
-	}
+	// conn, err := net.DialTimeout("tcp", "intake.logs.datadoghq.com:10514", 20*time.Second)
+	// if err != nil {
+	// 	return nil, fmt.Errorf("Failed to dial datadog - %s", err.Error())
+	// }
 
-	go handleServerClose(conn)
-	return &Datadog{Conn: conn, Key: key}, nil
+	cm := NewConnectionManager("intake.logs.datadoghq.com", 10514)
+	conn := cm.NewConnection()
+	cm.conn = conn
+
+	// go handleServerClose(conn)
+	// return &Datadog{Conn: conn, Key: key, connManager: cm}, nil
+	return &Datadog{Key: key, connManager: cm}, nil
 }
 
 // Init initializes a connection to mist
@@ -55,7 +62,7 @@ func handleServerClose(conn net.Conn) {
 }
 
 // Publish utilizes mist's Publish to "drain" a log message
-func (p Datadog) Publish(msg logvac.Message) {
+func (p *Datadog) Publish2(msg logvac.Message) {
 	msg.PubTries++
 	if p.Conn == nil {
 		fmt.Println("Redialing datadog")
@@ -93,10 +100,151 @@ func (p Datadog) Publish(msg logvac.Message) {
 	}
 }
 
+func (p *Datadog) Publish3(msg logvac.Message) {
+	msg.PubTries++
+
+	if p.Conn == nil {
+		fmt.Println("Redialing datadog")
+		p.Conn = p.connManager.NewConnection() // blocks until a new conn is ready
+	}
+
+	var ms []byte
+	if len(msg.Raw) > 4 {
+		ms = append(append([]byte(p.Key+" "), msg.Raw[4:]...), []byte("\n")...)
+	} else {
+		ms = append(append([]byte(p.Key+" "), msg.Raw...), []byte("\n")...)
+	}
+	fmt.Printf("Sending %s", ms)
+
+	_, err := p.Conn.Write(ms)
+	if err != nil {
+		fmt.Printf("Failed writing log - %s %d\n", err.Error(), msg.PubTries)
+		p.connManager.CloseConnection(p.Conn)
+		p.Conn = nil
+		if msg.PubTries <= 3 {
+			time.Sleep(2 * time.Second)
+			p.Publish(msg)
+		}
+	}
+}
+
+func (p *Datadog) Publish(msg logvac.Message) {
+	msg.PubTries++
+
+	if p.connManager.conn == nil {
+		fmt.Println("Redialing datadog")
+		p.connManager.conn = p.connManager.NewConnection() // blocks until a new conn is ready
+	}
+
+	var ms []byte
+	if len(msg.Raw) > 4 {
+		ms = append(append([]byte(p.Key+" "), msg.Raw[4:]...), []byte("\n")...)
+	} else {
+		ms = append(append([]byte(p.Key+" "), msg.Raw...), []byte("\n")...)
+	}
+	fmt.Printf("Sending %s", ms)
+
+	_, err := p.connManager.conn.Write(ms)
+	if err != nil {
+		fmt.Printf("Failed writing log - %s %d\n", err.Error(), msg.PubTries)
+		p.connManager.CloseConnection(p.connManager.conn)
+		p.connManager.conn = nil
+		if msg.PubTries <= 3 {
+			time.Sleep(2 * time.Second)
+			p.Publish(msg)
+		}
+		// p.Publish(msg)
+	}
+}
+
 // Close closes the connection to datadog.
 func (p *Datadog) Close() error {
-	if p.Conn == nil {
+	if p.connManager.conn == nil {
 		return nil
 	}
-	return p.Conn.Close()
+	return p.connManager.conn.Close()
+}
+
+// Adapted from datadog-log-agent
+const (
+	backoffSleepTimeUnit = 2  // in seconds
+	maxBackoffSleepTime  = 30 // in seconds
+	timeout              = 20 * time.Second
+)
+
+// A ConnectionManager manages connections
+type ConnectionManager struct {
+	connectionString string
+	serverName       string
+
+	mutex   sync.Mutex
+	retries int
+
+	conn net.Conn
+}
+
+// NewConnectionManager returns an initialized ConnectionManager
+func NewConnectionManager(ddUrl string, ddPort int) *ConnectionManager {
+	return &ConnectionManager{
+		connectionString: fmt.Sprintf("%s:%d", ddUrl, ddPort),
+		serverName:       ddUrl,
+
+		mutex: sync.Mutex{},
+	}
+}
+
+// NewConnection returns an initialized connection to the intake.
+// It blocks until a connection is available
+func (cm *ConnectionManager) NewConnection() net.Conn {
+	cm.mutex.Lock()
+	defer cm.mutex.Unlock()
+
+	for {
+		if cm.conn != nil {
+			return cm.conn
+		}
+		fmt.Println("Connecting to the backend:", cm.connectionString)
+		cm.retries += 1
+		outConn, err := net.DialTimeout("tcp", cm.connectionString, timeout)
+		if err != nil {
+			fmt.Println(err)
+			cm.backoff()
+			continue
+		}
+
+		cm.retries = 0
+		go cm.handleServerClose(outConn)
+		return outConn
+	}
+}
+
+// CloseConnection closes a connection on the client side
+func (cm *ConnectionManager) CloseConnection(conn io.Closer) {
+	conn.Close()
+}
+
+// handleServerClose lets the connection manager detect when a connection
+// has been closed by the server, and closes it for the client.
+func (cm *ConnectionManager) handleServerClose(conn net.Conn) {
+	for {
+		buff := make([]byte, 1)
+		_, err := conn.Read(buff)
+		if err == io.EOF {
+			cm.CloseConnection(conn)
+			return
+		} else if err != nil {
+			fmt.Println(err)
+			return
+		}
+	}
+}
+
+// backoff lets the connection mananger sleep a bit
+func (cm *ConnectionManager) backoff() {
+	backoffDuration := backoffSleepTimeUnit * cm.retries
+	if backoffDuration > maxBackoffSleepTime {
+		backoffDuration = maxBackoffSleepTime
+	}
+	timer := time.NewTimer(time.Second * time.Duration(backoffDuration))
+	<-timer.C
 }

--- a/drain/drain.go
+++ b/drain/drain.go
@@ -196,6 +196,21 @@ func AddDrain(d logvac.Drain) error {
 		}
 		drains["papertrail"] = pTrail
 		drainCfg["papertrail"] = d
+	case "datadog":
+		// if it already exists, close it and create a new one
+		if _, ok := drains["datadog"]; ok {
+			drains["datadog"].Close()
+		}
+		dDog, err := NewDatadogClient(d.AuthKey)
+		if err != nil {
+			return fmt.Errorf("Failed to create datadog client - %s", err)
+		}
+		err = dDog.Init()
+		if err != nil {
+			return fmt.Errorf("Datadog failed to initialize - %s", err)
+		}
+		drains["datadog"] = dDog
+		drainCfg["datadog"] = d
 	default:
 		return fmt.Errorf("Drain type not supported")
 	}

--- a/drain/papertrail_test.go
+++ b/drain/papertrail_test.go
@@ -27,7 +27,7 @@ func TestPTrailPublish(t *testing.T) {
 
 	trailTest.Publish(msg)
 	if b.String() != string(msg.Raw) {
-		t.Fatal("Failed to publish - '%s'", b.String())
+		t.Fatalf("Failed to publish - '%s'", b.String())
 	}
 	trailTest.Close()
 }


### PR DESCRIPTION
Adds a datadog log endpoint as a drain.

-----------------------
To configure:
```sh
curl -k -H "X-Auth-Token: ${LOGGER_DATA_LOGVAC_TOKEN}" \
  https://${LOGGER_DATA_LOGVAC_HOST}:6361/drains \
  -d '{"type":"datadog","key":"DATADOG_API_TOKEN"}'
```
-----------------------
To remove:
```sh
curl -k -H "X-Auth-Token: ${LOGGER_DATA_LOGVAC_TOKEN}" \
  https://${LOGGER_DATA_LOGVAC_HOST}:6361/drains/datadog \
  -X DELETE
```